### PR TITLE
fix field order in the PyTypeObject structure

### DIFF
--- a/src/commutron.cpp
+++ b/src/commutron.cpp
@@ -31,14 +31,14 @@ static void PyErlNifEnvObject_dealloc(PyErlNifEnvObject* self);
 static PyTypeObject PyErlNifEnvObjectType = {
   PyVarObject_HEAD_INIT(NULL, 0)
   .tp_name = "commutron.PyErlNifEnvObject",
-  .tp_doc = "Erlang/OTP ErlNifEnv object wrapper",
   .tp_basicsize = sizeof(PyErlNifEnvObject),
   .tp_itemsize = 0,
-  .tp_flags = Py_TPFLAGS_DEFAULT,
-  .tp_new = PyErlNifEnvObject_new,
-  .tp_init = NULL,
   .tp_dealloc = (destructor)PyErlNifEnvObject_dealloc,
+  .tp_flags = Py_TPFLAGS_DEFAULT,
+  .tp_doc = "Erlang/OTP ErlNifEnv object wrapper",
   .tp_methods = PyErlNifEnvObject_methods,
+  .tp_init = NULL,
+  .tp_new = PyErlNifEnvObject_new,
 };
 
 static void PyErlNifEnvObject_dealloc(PyErlNifEnvObject* self) {


### PR DESCRIPTION
It was failing on python project setup (second cell in LiveBook)

```
Using CPython 3.11.11
Creating virtual environment at: .venv
Resolved 2 packages in 12ms
  × Failed to build `commutron @ file:///home/daniil/lalabuy/commutron`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

      [stdout]
      running bdist_wheel
      running build
      running build_py
      creating build/lib.linux-x86_64-cpython-311/commutron
      copying commutron/__init__.py ->
      build/lib.linux-x86_64-cpython-311/commutron
      running egg_info
      writing commutron.egg-info/PKG-INFO
      writing dependency_links to commutron.egg-info/dependency_links.txt
      writing top-level names to commutron.egg-info/top_level.txt
      reading manifest file 'commutron.egg-info/SOURCES.txt'
      writing manifest file 'commutron.egg-info/SOURCES.txt'
      running build_ext
      building 'commutron.core' extension
      creating build/temp.linux-x86_64-cpython-311/src
      c++ -pthread -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3
      -Wall -fPIC -fPIC -I/home/daniil/.cache/uv/builds-v0/.tmpC5fdVb/include
      -I/home/daniil/.cache/pythonx/0.4.5-dev/uv/0.5.21/python/cpython-3.11.11-linux-x86_64-gnu/include/python3.11
      -c src/commutron.cpp -o
      build/temp.linux-x86_64-cpython-311/src/commutron.o -O3 -std=c++17 -fPIC

      [stderr]
      src/commutron.cpp:42:1: error: designator order for field
      ‘_typeobject::tp_basicsize’ does not match declaration order in
      ‘PyTypeObject’ {aka ‘_typeobject’}
         42 | };
            | ^
      src/commutron.cpp:19:1: warning: ‘PyObject*
      PyErlNifEnvObject_new(PyTypeObject*, PyObject*, PyObject*)’ defined but
      not used [-Wunused-function]
         19 | PyErlNifEnvObject_new(PyTypeObject* type, PyObject* args,
      PyObject* kwds) {
            | ^~~~~~~~~~~~~~~~~~~~~
      error: command '/usr/bin/c++' failed with exit code 1

      hint: This usually indicates a problem with the package or the build
      environment.
  help: `commutron` was included because `project` (v0.0.1) depends on
        `commutron`

```

Now it's ok: 

![image](https://github.com/user-attachments/assets/36bdecd4-85f3-45fc-ad02-c4917ee23ab0)
